### PR TITLE
[Test] Add slice conversion benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ make bench
 | Benchmark                          | Iterations | ns/op | B/op | allocs/op |
 |------------------------------------|------------|------:|-----:|----------:|
 | [Greet](tx_map_benchmarks_test.go) | 21,179,739 | 56.59 |   40 |         2 |
+| [ConvertSyncMapToUint32Slice](tx_map_benchmarks_test.go) | 78,904 | 15365 | 12920 | 11 |
+| [ConvertSyncedMapToUint32Slice](tx_map_benchmarks_test.go) | 46,190 | 22160 | 12920 | 11 |
 
 > These benchmarks reflect fast, allocation-free lookups for most retrieval functions, ensuring optimal performance in production environments.
 > Performance benchmarks for the core functions in this library, executed on an Apple M1 Max (ARM64).

--- a/tx_map_benchmarks_test.go
+++ b/tx_map_benchmarks_test.go
@@ -1,1 +1,42 @@
 package txmap
+
+import (
+	"sync"
+	"testing"
+)
+
+// BenchmarkConvertSyncMapToUint32Slice measures the performance of converting
+// a sync.Map to a slice of uint32 values.
+func BenchmarkConvertSyncMapToUint32Slice(b *testing.B) {
+	var sm sync.Map
+	for i := 0; i < 1000; i++ {
+		sm.Store(uint32(i), struct{}{}) //nolint:gosec // safe cast, i < 1000
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, ok := ConvertSyncMapToUint32Slice(&sm); !ok {
+			b.Fatal("map should contain elements")
+		}
+	}
+}
+
+// BenchmarkConvertSyncedMapToUint32Slice measures the performance of converting
+// a SyncedMap to a slice of uint32 values.
+func BenchmarkConvertSyncedMapToUint32Slice(b *testing.B) {
+	sm := NewSyncedMap[int, []uint32]()
+	for i := 0; i < 1000; i++ {
+		sm.Set(i, []uint32{uint32(i)}) //nolint:gosec // safe cast, i < 1000
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, ok := ConvertSyncedMapToUint32Slice[int](sm); !ok {
+			b.Fatal("map should contain elements")
+		}
+	}
+}


### PR DESCRIPTION
## What Changed
- Added benchmark tests for `ConvertSyncMapToUint32Slice` and `ConvertSyncedMapToUint32Slice`
- Documented the new benchmark numbers in the README

## Why It Was Necessary
These benchmarks quantify the performance of the map‐to‐slice conversion helpers and provide concrete numbers for users evaluating this package.

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `make bench`

## Impact / Risk
- No breaking changes
- Minimal risk; changes limited to benchmarks and documentation.

------
https://chatgpt.com/codex/tasks/task_e_6864915df1608321946df6a60135820f