### PR TITLE
[Test] Add fuzz test for Bytes2Uint16Buckets

### DIFF
--- a/tx_map_fuzz_test.go
+++ b/tx_map_fuzz_test.go
@@ -1,1 +1,51 @@
 package txmap
+
+import (
+	"testing"
+
+	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzBytes2Uint16Buckets verifies that Bytes2Uint16Buckets produces
+// deterministic results for arbitrary hashes and non-zero modulus values.
+//
+// The fuzz test seeds the corpus with several representative hash and
+// modulus pairs and then checks that:
+//  1. The returned value is always less than the provided modulus.
+//  2. The value matches the expected manual calculation.
+func FuzzBytes2Uint16Buckets(f *testing.F) {
+	// Seed with edge cases from unit tests to guide the fuzzer.
+	seeds := []struct {
+		data []byte
+		mod  uint16
+	}{
+		{data: []byte{0x00, 0x01}, mod: 256},
+		{data: []byte{0xff, 0xff}, mod: 1024},
+		{data: []byte{0x12, 0x34}, mod: 10},
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed.data, seed.mod)
+	}
+
+	f.Fuzz(func(t *testing.T, b []byte, mod uint16) {
+		if mod == 0 {
+			t.Skip("mod cannot be zero")
+		}
+		if len(b) < 2 {
+			t.Skip("need at least two bytes")
+		}
+
+		var hash chainhash.Hash
+		copy(hash[:], b)
+
+		got := Bytes2Uint16Buckets(hash, mod)
+
+		expected := (uint16(hash[0])<<8 | uint16(hash[1])) % mod
+
+		require.Less(t, got, mod)
+		assert.Equal(t, expected, got)
+	})
+}


### PR DESCRIPTION
## What Changed
- Added a fuzz test in `tx_map_fuzz_test.go` that exercises `Bytes2Uint16Buckets`

## Why It Was Necessary
- Increases test coverage and validates the function across random inputs

## Testing Performed
- `golangci-lint run --verbose`
- `go test ./... -v`
- `make run-fuzz-tests`

## Impact / Risk
- Low; adds a self-contained fuzz test with no functional code changes

------
https://chatgpt.com/codex/tasks/task_e_686491868a148321b45b14cd6088b81f