### PR TITLE
[Test] Add constructor benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,15 @@ make bench
 
 | Benchmark                                                  | Iterations | ns/op |  B/op | allocs/op |
 |------------------------------------------------------------|------------|------:|------:|----------:|
-| [ConvertSyncMapToUint32Slice](tx_map_benchmarks_test.go)   | 78,904     | 15365 | 12920 |        11 |
-| [ConvertSyncedMapToUint32Slice](tx_map_benchmarks_test.go) | 46,190     | 22160 | 12920 |        11 |
+| [Bytes2Uint16Buckets](tx_map_benchmarks_test.go)           | 1,000,000,000 |     1 |     0 |         0 |
+| [ConvertSyncMapToUint32Slice](tx_map_benchmarks_test.go)   | 86,636     | 13312 | 12920 |        11 |
+| [ConvertSyncedMapToUint32Slice](tx_map_benchmarks_test.go) | 57,505     | 20754 | 12920 |        11 |
+| [NewSplitSwissLockFreeMapUint64](tx_map_benchmarks_test.go)| 4,792     | 414742 | 442192 |      4112 |
+| [NewSplitSwissMap](tx_map_benchmarks_test.go)              | 2,715     | 423537 | 840626 |      4107 |
+| [NewSplitSwissMapUint64](tx_map_benchmarks_test.go)        | 2,401     | 465790 | 868603 |      4112 |
+| [NewSwissLockFreeMapUint64](tx_map_benchmarks_test.go)     | 251,127     | 5740 | 19664 |         3 |
+| [NewSwissMap](tx_map_benchmarks_test.go)                   | 117,189     | 9331 | 42192 |         3 |
+| [NewSwissMapUint64](tx_map_benchmarks_test.go)             | 125,695     | 11093 | 50384 |         3 |
 
 > These benchmarks reflect fast, allocation-free lookups for most retrieval functions, ensuring optimal performance in production environments.
 > Performance benchmarks for the core functions in this library, executed on an Apple M1 Max (ARM64).

--- a/tx_map_benchmarks_test.go
+++ b/tx_map_benchmarks_test.go
@@ -3,7 +3,21 @@ package txmap
 import (
 	"sync"
 	"testing"
+
+	"github.com/libsv/go-bt/v2/chainhash"
 )
+
+// BenchmarkBytes2Uint16Buckets measures the performance of Bytes2Uint16Buckets.
+func BenchmarkBytes2Uint16Buckets(b *testing.B) {
+	hash := chainhash.Hash{0x01, 0x02}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = Bytes2Uint16Buckets(hash, 1024)
+	}
+}
 
 // BenchmarkConvertSyncMapToUint32Slice measures the performance of converting
 // a sync.Map to a slice of uint32 values.
@@ -37,6 +51,79 @@ func BenchmarkConvertSyncedMapToUint32Slice(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		if _, ok := ConvertSyncedMapToUint32Slice[int](sm); !ok {
 			b.Fatal("map should contain elements")
+		}
+	}
+}
+
+// BenchmarkNewSplitSwissLockFreeMapUint64 measures constructing a
+// SplitSwissLockFreeMapUint64.
+func BenchmarkNewSplitSwissLockFreeMapUint64(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if NewSplitSwissLockFreeMapUint64(1000) == nil {
+			b.Fatal("map should not be nil")
+		}
+	}
+}
+
+// BenchmarkNewSplitSwissMap measures constructing a SplitSwissMap.
+func BenchmarkNewSplitSwissMap(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if NewSplitSwissMap(1000) == nil {
+			b.Fatal("map should not be nil")
+		}
+	}
+}
+
+// BenchmarkNewSplitSwissMapUint64 measures constructing a SplitSwissMapUint64.
+func BenchmarkNewSplitSwissMapUint64(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if NewSplitSwissMapUint64(1000) == nil {
+			b.Fatal("map should not be nil")
+		}
+	}
+}
+
+// BenchmarkNewSwissLockFreeMapUint64 measures constructing a SwissLockFreeMapUint64.
+func BenchmarkNewSwissLockFreeMapUint64(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if NewSwissLockFreeMapUint64(1000) == nil {
+			b.Fatal("map should not be nil")
+		}
+	}
+}
+
+// BenchmarkNewSwissMap measures constructing a SwissMap.
+func BenchmarkNewSwissMap(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if NewSwissMap(1000) == nil {
+			b.Fatal("map should not be nil")
+		}
+	}
+}
+
+// BenchmarkNewSwissMapUint64 measures constructing a SwissMapUint64.
+func BenchmarkNewSwissMapUint64(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if NewSwissMapUint64(1000) == nil {
+			b.Fatal("map should not be nil")
 		}
 	}
 }


### PR DESCRIPTION
## What Changed
- add benchmarks for constructors and utility
- update benchmark table in README with results

## Why It Was Necessary
- measure performance of map constructors and Bytes2Uint16Buckets

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`
- `make govulncheck` *(fails: detected standard library vulnerability)*
- `go test -bench=. -benchmem`

## Impact / Risk
- no breaking changes
- adds benchmark functions only

------
https://chatgpt.com/codex/tasks/task_e_68649904ab008321b9e9baf2e5b14f54