### PR TITLE
Migrate to bsv-blockchain go-bt dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/bsv-blockchain/go-tx-map
 go 1.24
 
 require (
+	github.com/bsv-blockchain/go-bt/v2 v2.3.0
 	github.com/dolthub/swiss v0.2.1
-	github.com/libsv/go-bt/v2 v2.2.5
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -17,5 +17,3 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/libsv/go-bt/v2 => github.com/ordishs/go-bt/v2 v2.2.22

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bsv-blockchain/go-bt/v2 v2.3.0 h1:ZEFtKV93wq59qna9/DEp4NJmVb5hZgF3h1vGXNLKMeU=
+github.com/bsv-blockchain/go-bt/v2 v2.3.0/go.mod h1:NzalErv8cCi3VDZYNLaHxnP2PiiDFIQS6dgQgBGTV4A=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -11,8 +13,6 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/ordishs/go-bt/v2 v2.2.22 h1:5WmTQoX74g9FADM9hpbXZOE34uep4EqeSwpIy4CbWYE=
-github.com/ordishs/go-bt/v2 v2.2.22/go.mod h1:bOaZFOoazYognJH/nfcBjuDFud1XmIc05n7bp4Tvvfk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/tx_map.go
+++ b/tx_map.go
@@ -49,7 +49,7 @@
 //
 // Dependencies:
 // The package depends on the [`swiss`](https://github.com/dolthub/swiss) library and
-// additionally uses the `chainhash` library (`github.com/libsv/go-bt/v2/chainhash`) where applicable.
+// additionally uses the `chainhash` library (`github.com/bsv-blockchain/go-bt/v2/chainhash`) where applicable.
 package txmap
 
 import (
@@ -59,8 +59,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/dolthub/swiss"
-	"github.com/libsv/go-bt/v2/chainhash"
 )
 
 // TxMap is a map that stores transaction hashes and associated uint64 values.

--- a/tx_map_benchmarks_test.go
+++ b/tx_map_benchmarks_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // BenchmarkBytes2Uint16Buckets measures the performance of Bytes2Uint16Buckets.

--- a/tx_map_fuzz_test.go
+++ b/tx_map_fuzz_test.go
@@ -3,7 +3,7 @@ package txmap
 import (
 	"testing"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tx_map_test.go
+++ b/tx_map_test.go
@@ -3,7 +3,7 @@ package txmap
 import (
 	"testing"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
This pull request updates the dependency from `github.com/libsv/go-bt/v2` to `github.com/bsv-blockchain/go-bt/v2` across multiple files in the project. The changes involve modifying the `go.mod` file to reflect the new dependency and updating import statements in various source files to use the new library.

### Dependency Update:

* **`go.mod`**: Replaced `github.com/libsv/go-bt/v2 v2.2.5` with `github.com/bsv-blockchain/go-bt/v2 v2.3.0` and removed the `replace` directive for `github.com/libsv/go-bt/v2`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-L7) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L20-L21)

### Import Statement Updates:

* **`tx_map.go`**: Updated the import statement to use `github.com/bsv-blockchain/go-bt/v2/chainhash` instead of `github.com/libsv/go-bt/v2/chainhash`. [[1]](diffhunk://#diff-98fe896b03558993fedd68211b13d58ddb37a248f796b2c558df6a9be25ee2b9L52-R52) [[2]](diffhunk://#diff-98fe896b03558993fedd68211b13d58ddb37a248f796b2c558df6a9be25ee2b9R62-L63)
* **`tx_map_benchmarks_test.go`**: Changed the `chainhash` import to reference `github.com/bsv-blockchain/go-bt/v2/chainhash`.
* **`tx_map_fuzz_test.go`**: Updated the `chainhash` import to use `github.com/bsv-blockchain/go-bt/v2/chainhash`.
* **`tx_map_test.go`**: Modified the `chainhash` import to point to `github.com/bsv-blockchain/go-bt/v2/chainhash`.
