### PR TITLE
[Docs] Remove install-template command

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ govulncheck-install   ## Install govulncheck
 help                  ## Display this help message
 install-go            ## Install using go install with specific version
 install-releaser      ## Install GoReleaser
-install-template      ## Kick-start a fresh copy of go-tx-map (run once!)
 install               ## Install the application binary
 lint                  ## Run the golangci-lint application (install if not found)
 release-snap          ## Build snapshot binaries


### PR DESCRIPTION
## What Changed
- Removed the deprecated `install-template` entry from the Makefile command list in `README.md`

## Why It Was Necessary
- The command is no longer included in the Makefile and the README should accurately reflect available targets

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Low risk documentation update only


------
https://chatgpt.com/codex/tasks/task_e_6866b70d709c8321a00bb4b266483f90