### PR TITLE
feat(synced): add SetIfNotExistsMulti for single-lock bulk conditional insert

### DIFF
--- a/synced.go
+++ b/synced.go
@@ -190,6 +190,46 @@ func (m *SyncedMap[K, V]) SetMulti(keys []K, value V) {
 	}
 }
 
+// SetIfNotExistsMulti inserts each keys[i] -> values[i] pair under a single
+// write-lock acquisition. Matches SetIfNotExists semantics per element: if a
+// key already exists in the map its value is left unchanged.
+//
+// Parameters:
+//   - keys: A slice of keys to insert.
+//   - values: A slice of values to associate with each key. If shorter than
+//     keys, only the first len(values) pairs are considered.
+//
+// Returns:
+//   - []bool: A slice of length min(len(keys), len(values)). wasInserted[i]
+//     is true if keys[i] was newly added, false if the key already existed.
+//
+// Designed for bucket-affinity bulk inserts where the caller has pre-
+// partitioned its workload so a single bucket's map is written by a single
+// goroutine; eliminates the per-element Lock/Unlock overhead of calling
+// SetIfNotExists in a loop.
+func (m *SyncedMap[K, V]) SetIfNotExistsMulti(keys []K, values []V) []bool {
+	n := len(keys)
+	if len(values) < n {
+		n = len(values)
+	}
+
+	wasInserted := make([]bool, n)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i := 0; i < n; i++ {
+		if _, ok := m.m[keys[i]]; ok {
+			continue
+		}
+
+		m.setUnlocked(keys[i], values[i])
+		wasInserted[i] = true
+	}
+
+	return wasInserted
+}
+
 // Delete removes the key and its value from the SyncedMap.
 //
 // Parameters:

--- a/synced_test.go
+++ b/synced_test.go
@@ -128,6 +128,62 @@ func TestSyncedMapSetMulti(t *testing.T) {
 	assert.Equal(t, 1, m.m["key2"])
 }
 
+// TestSyncedMapSetIfNotExistsMulti tests the SetIfNotExistsMulti method of
+// SyncedMap including the per-element wasInserted contract and slice-length
+// mismatch handling.
+func TestSyncedMapSetIfNotExistsMulti(t *testing.T) {
+	t.Run("all new keys are inserted", func(t *testing.T) {
+		m := NewSyncedMap[string, int]()
+		wasInserted := m.SetIfNotExistsMulti([]string{"a", "b", "c"}, []int{1, 2, 3})
+
+		assert.Equal(t, []bool{true, true, true}, wasInserted)
+		assert.Equal(t, 1, m.m["a"])
+		assert.Equal(t, 2, m.m["b"])
+		assert.Equal(t, 3, m.m["c"])
+	})
+
+	t.Run("existing keys are preserved", func(t *testing.T) {
+		m := NewSyncedMap[string, int]()
+		m.Set("b", 99)
+
+		wasInserted := m.SetIfNotExistsMulti([]string{"a", "b", "c"}, []int{1, 2, 3})
+		assert.Equal(t, []bool{true, false, true}, wasInserted)
+		assert.Equal(t, 1, m.m["a"])
+		assert.Equal(t, 99, m.m["b"]) // preserved
+		assert.Equal(t, 3, m.m["c"])
+	})
+
+	t.Run("empty input returns empty slice", func(t *testing.T) {
+		m := NewSyncedMap[string, int]()
+		wasInserted := m.SetIfNotExistsMulti(nil, nil)
+		assert.Equal(t, []bool{}, wasInserted)
+		assert.Equal(t, 0, m.Length())
+	})
+
+	t.Run("values shorter than keys truncates to len(values)", func(t *testing.T) {
+		m := NewSyncedMap[string, int]()
+		wasInserted := m.SetIfNotExistsMulti([]string{"a", "b", "c"}, []int{1, 2})
+		assert.Equal(t, []bool{true, true}, wasInserted)
+		assert.Equal(t, 2, m.Length())
+		_, exists := m.m["c"]
+		assert.False(t, exists)
+	})
+
+	t.Run("keys shorter than values truncates to len(keys)", func(t *testing.T) {
+		m := NewSyncedMap[string, int]()
+		wasInserted := m.SetIfNotExistsMulti([]string{"a"}, []int{1, 2, 3})
+		assert.Equal(t, []bool{true}, wasInserted)
+		assert.Equal(t, 1, m.Length())
+	})
+
+	t.Run("duplicate keys within a single call: first wins", func(t *testing.T) {
+		m := NewSyncedMap[string, int]()
+		wasInserted := m.SetIfNotExistsMulti([]string{"a", "a", "a"}, []int{1, 2, 3})
+		assert.Equal(t, []bool{true, false, false}, wasInserted)
+		assert.Equal(t, 1, m.m["a"])
+	})
+}
+
 // TestSyncedMapDelete tests the Delete and Exists methods of SyncedMap.
 func TestSyncedMapDelete(t *testing.T) {
 	m := NewSyncedMap[string, int]()


### PR DESCRIPTION
## Summary

Adds `SyncedMap.SetIfNotExistsMulti(keys, values) []bool` — a bulk conditional-insert variant that takes the write-lock once for the whole batch instead of N times.

### Why

The existing single-key `SetIfNotExists` acquires the internal `RWMutex`, checks, optionally inserts, and releases. For callers that have already pre-partitioned their workload so a single goroutine owns a single SyncedMap shard (bucket-affinity bulk insert pattern), calling `SetIfNotExists` in a loop is correct but wasteful: each call does a separate Lock/Unlock even though the lock is held by the same goroutine across the loop.

This shape is common in sharded-map wrappers. For example, the consumer in [teranode block-assembly](https://github.com/bsv-blockchain/teranode) partitions ~30M tx hashes across 4096-16384 buckets and dispatches one goroutine per non-empty bucket. With the per-call lock pattern, profiling shows ~17 % of CPU inside `Lock`/`Unlock` even with no cross-worker contention — purely the per-call acquire/release overhead.

A single-lock bulk variant eliminates that overhead while preserving exact per-key SetIfNotExists semantics.

### API

```go
func (m *SyncedMap[K, V]) SetIfNotExistsMulti(keys []K, values []V) []bool
```

- Walks both slices under one `Lock`. For each `i`, if `keys[i]` is absent inserts `values[i]` via the existing `setUnlocked` (so the configured `limit`-based eviction still applies); otherwise leaves the existing value untouched.
- Returns a `[]bool` of length `min(len(keys), len(values))`; `wasInserted[i]` is `true` if newly added, `false` if the key already existed — mirrors the `(V, bool)` return shape of single-key `SetIfNotExists`.

### Edge-case behaviour (covered by tests)

| Input | Behaviour |
|---|---|
| `len(values) < len(keys)` | Truncates to `len(values)`; trailing keys ignored. |
| `len(keys) < len(values)` | Truncates to `len(keys)`; trailing values ignored. |
| Empty / nil input | Returns `[]bool{}`. |
| Duplicate keys within a single call | First wins — subsequent duplicates return `wasInserted=false`. |

### Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes (existing + new tests)
- [x] New tests: `TestSyncedMapSetIfNotExistsMulti` with five subtests covering the cases above

### Notes

- Purely additive — no existing API changes. Safe to backport to any consumer on the current minor version.
- The `setUnlocked` helper already exists and is reused as the per-element insert primitive, so the limit-based eviction logic is shared.