### PR TITLE
feat: add Freeze/Clear to map interfaces and implementations

### DIFF
--- a/freeze.go
+++ b/freeze.go
@@ -28,9 +28,19 @@ package txmap
 // phase). Freeze and Clear are not safe to call concurrently with other
 // operations on the same map.
 
-// Compile-time checks that every map type satisfies its interface, including
-// the Freeze/Clear methods now required by TxMap, TxHashMap and Uint64.
+// Compile-time checks that every concrete map type satisfies its interface,
+// including the Freeze/Clear methods now required by TxMap, TxHashMap and
+// Uint64. (The TxMap assertions are duplicated next to each type definition;
+// gathering all twelve here gives a single checklist that every implementation
+// gained the new methods.)
 var (
+	_ TxMap = (*SwissMapUint64)(nil)
+	_ TxMap = (*SplitSwissMap)(nil)
+	_ TxMap = (*SplitSwissMapUint64)(nil)
+	_ TxMap = (*NativeMapUint64)(nil)
+	_ TxMap = (*NativeSplitMap)(nil)
+	_ TxMap = (*NativeSplitMapUint64)(nil)
+
 	_ TxHashMap = (*SwissMap)(nil)
 	_ TxHashMap = (*NativeMap)(nil)
 
@@ -65,7 +75,9 @@ func (s *SwissLockFreeMapUint64) Clear() {
 func (s *NativeMap) Freeze() { s.frozen.Store(true) }
 
 // Clear empties the map (retaining its allocated capacity) and un-freezes it
-// for reuse. Safe for concurrent use — takes the write lock.
+// for reuse. Per the lifecycle contract above, Clear must not run concurrently
+// with other operations on the map (a frozen reader skips the lock that Clear
+// takes); the write lock only orders it against other locked, non-frozen ops.
 func (s *NativeMap) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -79,7 +91,9 @@ func (s *NativeMap) Clear() {
 func (s *NativeMapUint64) Freeze() { s.frozen.Store(true) }
 
 // Clear empties the map (retaining its allocated capacity) and un-freezes it
-// for reuse. Safe for concurrent use — takes the write lock.
+// for reuse. Per the lifecycle contract above, Clear must not run concurrently
+// with other operations on the map (a frozen reader skips the lock that Clear
+// takes); the write lock only orders it against other locked, non-frozen ops.
 func (s *NativeMapUint64) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/freeze.go
+++ b/freeze.go
@@ -1,0 +1,183 @@
+package txmap
+
+// Freeze / Clear lifecycle
+//
+// Freeze marks a map read-only. It exists to eliminate read-side lock
+// contention on the lock-based maps: once a map has been fully populated and
+// will only be read, Freeze lets every subsequent read (Exists, Get, Length,
+// Keys, Iter) skip the per-bucket RWMutex.RLock. Acquiring an RLock performs an
+// atomic add/sub on the reader counter, and under many cores reading the same
+// shard that cache line ping-pongs between CPUs and dominates the profile.
+// After Freeze, reads do a single relaxed atomic load of a bool flag instead.
+//
+// Once frozen, every write method (Put, PutMulti, Set, SetIfExists,
+// SetIfNotExists, Delete) returns ErrMapFrozen rather than silently mutating a
+// map that concurrent readers assume is immutable.
+//
+// On the lock-free maps (SwissLockFreeMapUint64, *LockFreeMapUint64 and their
+// split variants) reads already take no lock, so Freeze only installs the
+// write guard, for API uniformity.
+//
+// Clear empties the map in place — retaining the (potentially multi-GB)
+// preallocated backing storage — and un-freezes it, so a pooled map can be
+// recycled across uses: Clear -> Put... -> Freeze -> Get... -> Clear.
+//
+// HAPPENS-BEFORE CONTRACT: the caller must ensure all writes have completed
+// before calling Freeze, and that Freeze happens-before any reader observes the
+// frozen state (e.g. an errgroup.Wait between the write phase and the read
+// phase). Freeze and Clear are not safe to call concurrently with other
+// operations on the same map.
+
+// Compile-time checks that every map type satisfies its interface, including
+// the Freeze/Clear methods now required by TxMap, TxHashMap and Uint64.
+var (
+	_ TxHashMap = (*SwissMap)(nil)
+	_ TxHashMap = (*NativeMap)(nil)
+
+	_ Uint64 = (*SwissLockFreeMapUint64)(nil)
+	_ Uint64 = (*NativeLockFreeMapUint64)(nil)
+	_ Uint64 = (*SplitSwissLockFreeMapUint64)(nil)
+	_ Uint64 = (*NativeSplitLockFreeMapUint64)(nil)
+)
+
+// --- dolthub/swiss-backed leaf maps -----------------------------------------
+
+// Freeze marks the map read-only. See the lifecycle notes at the top of this file.
+func (s *SwissMap) Freeze() { s.frozen.Store(true) }
+
+// Freeze marks the map read-only. See the lifecycle notes at the top of this file.
+func (s *SwissMapUint64) Freeze() { s.frozen.Store(true) }
+
+// Freeze marks the map read-only; subsequent Put calls return ErrMapFrozen.
+func (s *SwissLockFreeMapUint64) Freeze() { s.frozen.Store(true) }
+
+// Clear empties the map without releasing the underlying backing storage and
+// un-freezes it for reuse. Not safe for concurrent use.
+func (s *SwissLockFreeMapUint64) Clear() {
+	s.m.Clear()
+	s.length.Store(0)
+	s.frozen.Store(false)
+}
+
+// --- native-map-backed leaf maps --------------------------------------------
+
+// Freeze marks the map read-only. See the lifecycle notes at the top of this file.
+func (s *NativeMap) Freeze() { s.frozen.Store(true) }
+
+// Clear empties the map (retaining its allocated capacity) and un-freezes it
+// for reuse. Safe for concurrent use — takes the write lock.
+func (s *NativeMap) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	clear(s.m)
+	s.length = 0
+	s.frozen.Store(false)
+}
+
+// Freeze marks the map read-only. See the lifecycle notes at the top of this file.
+func (s *NativeMapUint64) Freeze() { s.frozen.Store(true) }
+
+// Clear empties the map (retaining its allocated capacity) and un-freezes it
+// for reuse. Safe for concurrent use — takes the write lock.
+func (s *NativeMapUint64) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	clear(s.m)
+	s.length = 0
+	s.frozen.Store(false)
+}
+
+// Freeze marks the map read-only; subsequent Put calls return ErrMapFrozen.
+func (s *NativeLockFreeMapUint64) Freeze() { s.frozen.Store(true) }
+
+// Clear empties the map and un-freezes it for reuse. Not safe for concurrent use.
+func (s *NativeLockFreeMapUint64) Clear() {
+	clear(s.m)
+	s.length.Store(0)
+	s.frozen.Store(false)
+}
+
+// --- split maps: Freeze/Clear fan out to every bucket -----------------------
+
+// Freeze freezes every bucket, so reads across the whole split map become
+// lock-free. See the lifecycle notes at the top of this file.
+func (g *SplitSwissMap) Freeze() {
+	for i := uint16(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Freeze()
+	}
+}
+
+// Clear empties and un-freezes every bucket, recycling the split map for reuse.
+func (g *SplitSwissMap) Clear() {
+	for i := uint16(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Clear()
+	}
+}
+
+// Freeze freezes every bucket, so reads across the whole split map become
+// lock-free. See the lifecycle notes at the top of this file.
+func (g *SplitSwissMapUint64) Freeze() {
+	for i := uint16(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Freeze()
+	}
+}
+
+// Freeze freezes every bucket; subsequent Put calls return ErrMapFrozen.
+func (g *SplitSwissLockFreeMapUint64) Freeze() {
+	for i := uint64(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Freeze()
+	}
+}
+
+// Clear empties and un-freezes every bucket, recycling the split map for reuse.
+func (g *SplitSwissLockFreeMapUint64) Clear() {
+	for i := uint64(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Clear()
+	}
+}
+
+// Freeze freezes every bucket, so reads across the whole split map become
+// lock-free. See the lifecycle notes at the top of this file.
+func (g *NativeSplitMap) Freeze() {
+	for i := uint16(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Freeze()
+	}
+}
+
+// Clear empties and un-freezes every bucket, recycling the split map for reuse.
+func (g *NativeSplitMap) Clear() {
+	for i := uint16(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Clear()
+	}
+}
+
+// Freeze freezes every bucket, so reads across the whole split map become
+// lock-free. See the lifecycle notes at the top of this file.
+func (g *NativeSplitMapUint64) Freeze() {
+	for i := uint16(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Freeze()
+	}
+}
+
+// Clear empties and un-freezes every bucket, recycling the split map for reuse.
+func (g *NativeSplitMapUint64) Clear() {
+	for i := uint16(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Clear()
+	}
+}
+
+// Freeze freezes every bucket; subsequent Put calls return ErrMapFrozen.
+func (g *NativeSplitLockFreeMapUint64) Freeze() {
+	for i := uint64(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Freeze()
+	}
+}
+
+// Clear empties and un-freezes every bucket, recycling the split map for reuse.
+func (g *NativeSplitLockFreeMapUint64) Clear() {
+	for i := uint64(0); i <= g.nrOfBuckets; i++ {
+		g.m[i].Clear()
+	}
+}

--- a/freeze.go
+++ b/freeze.go
@@ -8,7 +8,9 @@ package txmap
 // Keys, Iter) skip the per-bucket RWMutex.RLock. Acquiring an RLock performs an
 // atomic add/sub on the reader counter, and under many cores reading the same
 // shard that cache line ping-pongs between CPUs and dominates the profile.
-// After Freeze, reads do a single relaxed atomic load of a bool flag instead.
+// After Freeze, reads do a single atomic load of a bool flag instead (Go's
+// sync/atomic operations are sequentially consistent, but a lone Load touches
+// only the flag's cache line and does not write, so it avoids the ping-pong).
 //
 // Once frozen, every write method (Put, PutMulti, Set, SetIfExists,
 // SetIfNotExists, Delete) returns ErrMapFrozen rather than silently mutating a

--- a/freeze_test.go
+++ b/freeze_test.go
@@ -8,13 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// hashN returns a deterministic chainhash.Hash derived from i. The first two
-// bytes carry i so that split maps (which bucket on the first two bytes)
-// distribute keys across buckets.
+// hashN returns a deterministic chainhash.Hash derived from i. i is stored
+// big-endian in the first two bytes to match Bytes2Uint16Buckets, which reads
+// b[0] as the high byte and b[1] as the low byte: bucket = (b[0]<<8 | b[1]) %
+// nrOfBuckets. So consecutive i map to bucket i%nrOfBuckets and spread evenly
+// across buckets, exercising split-bucket behaviour. Inputs in these tests stay
+// below 65536, so both bytes are exact.
 func hashN(i int) chainhash.Hash {
 	var h chainhash.Hash
-	h[0] = byte(i & 0xff)
-	h[1] = byte((i >> 8) & 0xff)
+	h[0] = byte((i >> 8) & 0xff)
+	h[1] = byte(i & 0xff)
 
 	return h
 }

--- a/freeze_test.go
+++ b/freeze_test.go
@@ -1,0 +1,211 @@
+package txmap
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// hashN returns a deterministic chainhash.Hash derived from i. The first two
+// bytes carry i so that split maps (which bucket on the first two bytes)
+// distribute keys across buckets.
+func hashN(i int) chainhash.Hash {
+	var h chainhash.Hash
+	h[0] = byte(i & 0xff)
+	h[1] = byte((i >> 8) & 0xff)
+
+	return h
+}
+
+// txMapImpls returns a fresh instance of every concrete type that implements
+// TxMap, keyed by type name.
+func txMapImpls() map[string]func() TxMap {
+	return map[string]func() TxMap{
+		"SwissMapUint64":       func() TxMap { return NewSwissMapUint64(1024) },
+		"SplitSwissMap":        func() TxMap { return NewSplitSwissMap(1024) },
+		"SplitSwissMapUint64":  func() TxMap { return NewSplitSwissMapUint64(1024) },
+		"NativeMapUint64":      func() TxMap { return NewNativeMapUint64(1024) },
+		"NativeSplitMap":       func() TxMap { return NewNativeSplitMap(1024) },
+		"NativeSplitMapUint64": func() TxMap { return NewNativeSplitMapUint64(1024) },
+	}
+}
+
+// txHashMapImpls returns a fresh instance of every concrete type that
+// implements TxHashMap, keyed by type name.
+func txHashMapImpls() map[string]func() TxHashMap {
+	return map[string]func() TxHashMap{
+		"SwissMap":  func() TxHashMap { return NewSwissMap(1024) },
+		"NativeMap": func() TxHashMap { return NewNativeMap(1024) },
+	}
+}
+
+// uint64Impls returns a fresh instance of every concrete type that implements
+// Uint64, keyed by type name.
+func uint64Impls() map[string]func() Uint64 {
+	return map[string]func() Uint64{
+		"SwissLockFreeMapUint64":       func() Uint64 { return NewSwissLockFreeMapUint64(1024) },
+		"NativeLockFreeMapUint64":      func() Uint64 { return NewNativeLockFreeMapUint64(1024) },
+		"SplitSwissLockFreeMapUint64":  func() Uint64 { return NewSplitSwissLockFreeMapUint64(1024) },
+		"NativeSplitLockFreeMapUint64": func() Uint64 { return NewNativeSplitLockFreeMapUint64(1024) },
+	}
+}
+
+// TestTxMapFreeze verifies the Freeze/Clear contract for every TxMap
+// implementation: reads keep working while frozen, every write method fails
+// with ErrMapFrozen, and Clear empties the map and un-freezes it for reuse.
+func TestTxMapFreeze(t *testing.T) {
+	for name, factory := range txMapImpls() {
+		t.Run(name, func(t *testing.T) {
+			m := factory()
+
+			h1 := hashN(1)
+			require.NoError(t, m.Put(h1, 42))
+
+			m.Freeze()
+
+			// Reads still work while frozen.
+			v, ok := m.Get(h1)
+			require.True(t, ok)
+			require.Equal(t, uint64(42), v)
+			require.True(t, m.Exists(h1))
+			require.Equal(t, 1, m.Length())
+
+			// Every write fails loudly with ErrMapFrozen.
+			h2 := hashN(2)
+			require.ErrorIs(t, m.Put(h2, 7), ErrMapFrozen)
+			require.ErrorIs(t, m.PutMulti([]chainhash.Hash{h2}, 7), ErrMapFrozen)
+			require.ErrorIs(t, m.Set(h1, 9), ErrMapFrozen)
+
+			_, err := m.SetIfExists(h1, 9)
+			require.ErrorIs(t, err, ErrMapFrozen)
+
+			_, err = m.SetIfNotExists(h2, 7)
+			require.ErrorIs(t, err, ErrMapFrozen)
+
+			require.ErrorIs(t, m.Delete(h1), ErrMapFrozen)
+
+			// The frozen write must not have mutated the map.
+			require.Equal(t, 1, m.Length())
+
+			// Clear empties and un-freezes: writes work again.
+			m.Clear()
+			require.Equal(t, 0, m.Length())
+			require.NoError(t, m.Put(h2, 7))
+
+			v, ok = m.Get(h2)
+			require.True(t, ok)
+			require.Equal(t, uint64(7), v)
+		})
+	}
+}
+
+// TestTxHashMapFreeze verifies the Freeze/Clear contract for every TxHashMap
+// implementation.
+func TestTxHashMapFreeze(t *testing.T) {
+	for name, factory := range txHashMapImpls() {
+		t.Run(name, func(t *testing.T) {
+			m := factory()
+
+			h1 := hashN(1)
+			require.NoError(t, m.Put(h1))
+
+			m.Freeze()
+
+			require.True(t, m.Exists(h1))
+			require.Equal(t, 1, m.Length())
+
+			h2 := hashN(2)
+			require.ErrorIs(t, m.Put(h2), ErrMapFrozen)
+			require.ErrorIs(t, m.PutMulti([]chainhash.Hash{h2}), ErrMapFrozen)
+			require.ErrorIs(t, m.Delete(h1), ErrMapFrozen)
+
+			require.Equal(t, 1, m.Length())
+
+			m.Clear()
+			require.Equal(t, 0, m.Length())
+			require.NoError(t, m.Put(h2))
+			require.True(t, m.Exists(h2))
+		})
+	}
+}
+
+// TestUint64MapFreeze verifies the Freeze/Clear contract for every Uint64
+// (lock-free) implementation. Reads remain lock-free; Freeze only guards writes.
+func TestUint64MapFreeze(t *testing.T) {
+	for name, factory := range uint64Impls() {
+		t.Run(name, func(t *testing.T) {
+			m := factory()
+
+			require.NoError(t, m.Put(1, 42))
+
+			m.Freeze()
+
+			v, ok := m.Get(1)
+			require.True(t, ok)
+			require.Equal(t, uint64(42), v)
+			require.True(t, m.Exists(1))
+			require.Equal(t, 1, m.Length())
+
+			require.ErrorIs(t, m.Put(2, 7), ErrMapFrozen)
+			require.Equal(t, 1, m.Length())
+
+			m.Clear()
+			require.Equal(t, 0, m.Length())
+			require.NoError(t, m.Put(2, 7))
+
+			v, ok = m.Get(2)
+			require.True(t, ok)
+			require.Equal(t, uint64(7), v)
+		})
+	}
+}
+
+// readAllFrozen reads keys 0..n-1 from a frozen map and reports any mismatch.
+// Extracted from TestFrozenConcurrentReads so each goroutine body stays simple.
+func readAllFrozen(t *testing.T, m TxMap, n int) {
+	t.Helper()
+
+	for i := 0; i < n; i++ {
+		v, ok := m.Get(hashN(i))
+		if !ok || v != uint64(i) {
+			t.Errorf("frozen read mismatch at %d: got (%d,%v)", i, v, ok)
+			return
+		}
+	}
+}
+
+// TestFrozenConcurrentReads asserts that, once frozen, a TxMap can be read
+// concurrently from many goroutines without a data race. This is the whole
+// point of Freeze: the read path skips the per-bucket RWMutex. Run under -race.
+func TestFrozenConcurrentReads(t *testing.T) {
+	const (
+		n       = 2000
+		readers = 8
+	)
+
+	for name, factory := range txMapImpls() {
+		t.Run(name, func(t *testing.T) {
+			m := factory()
+			for i := 0; i < n; i++ {
+				require.NoError(t, m.Put(hashN(i), uint64(i)))
+			}
+
+			m.Freeze()
+
+			var wg sync.WaitGroup
+
+			wg.Add(readers)
+
+			for r := 0; r < readers; r++ {
+				go func() {
+					defer wg.Done()
+					readAllFrozen(t, m, n)
+				}()
+			}
+
+			wg.Wait()
+		})
+	}
+}

--- a/tx_map.go
+++ b/tx_map.go
@@ -76,6 +76,15 @@ type TxMap interface {
 	SetIfExists(hash chainhash.Hash, value uint64) (bool, error)
 	SetIfNotExists(hash chainhash.Hash, value uint64) (bool, error)
 	Iter(f func(hash chainhash.Hash, value uint64) bool)
+
+	// Freeze marks the map read-only. After Freeze, read methods skip locking
+	// (on lock-based implementations) and every write method returns ErrMapFrozen.
+	// Clear un-freezes. See the package-level Freeze documentation in freeze.go.
+	Freeze()
+
+	// Clear empties the map in place (retaining preallocated capacity) and
+	// un-freezes it, so a pooled map can be recycled for the next use.
+	Clear()
 }
 
 // Uint64 is a map that stores uint64's and associated uint64 value.
@@ -84,6 +93,12 @@ type Uint64 interface {
 	Get(hash uint64) (uint64, bool)
 	Length() int
 	Put(hash, value uint64) error
+
+	// Freeze marks the map read-only; subsequent Put calls return ErrMapFrozen.
+	Freeze()
+
+	// Clear empties the map and un-freezes it for reuse.
+	Clear()
 }
 
 // TxHashMap is a map that stores transaction hashes without any associated value.
@@ -96,6 +111,12 @@ type TxHashMap interface {
 	Put(hash chainhash.Hash) error
 	PutMulti(hashes []chainhash.Hash) error
 	Iter(f func(hash chainhash.Hash, value uint64) bool)
+
+	// Freeze marks the map read-only; subsequent writes return ErrMapFrozen.
+	Freeze()
+
+	// Clear empties the map and un-freezes it for reuse.
+	Clear()
 }
 
 // SwissMap is a simple concurrent-safe map that uses the swiss package
@@ -103,6 +124,7 @@ type SwissMap struct {
 	mu     sync.RWMutex
 	m      *swiss.Map[chainhash.Hash, struct{}]
 	length int
+	frozen atomic.Bool
 }
 
 var (
@@ -114,6 +136,11 @@ var (
 
 	// ErrBucketDoesNotExist is when a bucket doesn't exist
 	ErrBucketDoesNotExist = errors.New("bucket does not exist")
+
+	// ErrMapFrozen is returned by write methods (Put, PutMulti, Set,
+	// SetIfExists, SetIfNotExists, Delete) once Freeze has been called on the
+	// map. Call Clear to un-freeze and reuse the map.
+	ErrMapFrozen = errors.New("map is frozen and cannot be modified")
 )
 
 const (
@@ -147,8 +174,10 @@ func NewSwissMap(length uint32) *SwissMap {
 // Returns:
 //   - bool: True if the hash exists in the map, false otherwise.
 func (s *SwissMap) Exists(hash chainhash.Hash) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	_, ok := s.m.Get(hash)
 
@@ -165,8 +194,10 @@ func (s *SwissMap) Exists(hash chainhash.Hash) bool {
 //   - uint64: Always returns 0, as this map does not store values.
 //   - bool: True if the hash was found in the map, false otherwise.
 func (s *SwissMap) Get(hash chainhash.Hash) (uint64, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	_, ok := s.m.Get(hash)
 
@@ -181,6 +212,10 @@ func (s *SwissMap) Get(hash chainhash.Hash) (uint64, bool) {
 // Returns:
 //   - error: always returns nil, as this map does not have any constraints on adding hashes.
 func (s *SwissMap) Put(hash chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -199,6 +234,10 @@ func (s *SwissMap) Put(hash chainhash.Hash) error {
 // Returns:
 //   - error: always returns nil, as this map does not have any constraints on adding hashes.
 func (s *SwissMap) PutMulti(hashes []chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -219,6 +258,10 @@ func (s *SwissMap) PutMulti(hashes []chainhash.Hash) error {
 // Returns:
 //   - error: always returns nil, as this map does not have any constraints on deleting hashes.
 func (s *SwissMap) Delete(hash chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -234,8 +277,10 @@ func (s *SwissMap) Delete(hash chainhash.Hash) error {
 // Returns:
 //   - int: The number of hashes currently stored in the map.
 func (s *SwissMap) Length() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	return s.length
 }
@@ -249,6 +294,7 @@ func (s *SwissMap) Clear() {
 
 	s.m.Clear()
 	s.length = 0
+	s.frozen.Store(false)
 }
 
 // Keys returns a slice of all hashes currently stored in the map.
@@ -258,8 +304,10 @@ func (s *SwissMap) Clear() {
 // Returns:
 //   - []chainhash.Hash: A slice containing all the hashes in the map.
 func (s *SwissMap) Keys() []chainhash.Hash {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	keys := make([]chainhash.Hash, 0, s.length)
 
@@ -282,8 +330,10 @@ func (s *SwissMap) Map() TxHashMap {
 // Params:
 //   - f: A function that takes a hash and its associated value (always 0 in this map).
 func (s *SwissMap) Iter(f func(hash chainhash.Hash, value uint64) bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	s.m.Iter(func(k chainhash.Hash, _ struct{}) (stop bool) {
 		return f(k, 0)
@@ -299,6 +349,7 @@ type SwissMapUint64 struct {
 	mu     sync.RWMutex
 	m      *swiss.Map[chainhash.Hash, uint64]
 	length int
+	frozen atomic.Bool
 }
 
 // NewSwissMapUint64 creates a new SwissMapUint64 with the specified initial length.
@@ -333,8 +384,10 @@ func (s *SwissMapUint64) Map() *swiss.Map[chainhash.Hash, uint64] {
 // Returns:
 //   - bool: True if the hash exists in the map, false otherwise.
 func (s *SwissMapUint64) Exists(hash chainhash.Hash) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	_, ok := s.m.Get(hash)
 
@@ -352,6 +405,10 @@ func (s *SwissMapUint64) Exists(hash chainhash.Hash) bool {
 // Returns:
 //   - error: An error if the hash already exists in the map, nil otherwise.
 func (s *SwissMapUint64) Put(hash chainhash.Hash, n uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -378,6 +435,10 @@ func (s *SwissMapUint64) Put(hash chainhash.Hash, n uint64) error {
 // Returns:
 //   - error: An error if any of the hashes already exist in the map, nil otherwise.
 func (s *SwissMapUint64) PutMulti(hashes []chainhash.Hash, n uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -405,6 +466,10 @@ func (s *SwissMapUint64) PutMulti(hashes []chainhash.Hash, n uint64) error {
 // Returns:
 //   - error: An error if the hash does not exist in the map, nil otherwise.
 func (s *SwissMapUint64) Set(hash chainhash.Hash, value uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -429,6 +494,10 @@ func (s *SwissMapUint64) Set(hash chainhash.Hash, value uint64) error {
 //   - bool: True if the hash was found and updated, false otherwise.
 //   - error: An error if there was an issue updating the hash, nil otherwise.
 func (s *SwissMapUint64) SetIfExists(hash chainhash.Hash, value uint64) (bool, error) {
+	if s.frozen.Load() {
+		return false, ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -453,6 +522,10 @@ func (s *SwissMapUint64) SetIfExists(hash chainhash.Hash, value uint64) (bool, e
 //   - bool: True if the hash was added, false if it already existed.
 //   - error: An error if there was an issue adding the hash, nil otherwise.
 func (s *SwissMapUint64) SetIfNotExists(hash chainhash.Hash, value uint64) (bool, error) {
+	if s.frozen.Load() {
+		return false, ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -478,8 +551,10 @@ func (s *SwissMapUint64) SetIfNotExists(hash chainhash.Hash, value uint64) (bool
 //   - uint64: The value associated with the hash, or 0 if the hash does not exist.
 //   - bool: True if the hash was found in the map, false otherwise.
 func (s *SwissMapUint64) Get(hash chainhash.Hash) (uint64, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	n, ok := s.m.Get(hash)
 	if !ok {
@@ -495,8 +570,10 @@ func (s *SwissMapUint64) Get(hash chainhash.Hash) (uint64, bool) {
 // Returns:
 //   - int: The number of hashes currently stored in the map.
 func (s *SwissMapUint64) Length() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	return s.length
 }
@@ -514,6 +591,7 @@ func (s *SwissMapUint64) Clear() {
 
 	s.m.Clear()
 	s.length = 0
+	s.frozen.Store(false)
 }
 
 // Keys returns a slice of all hashes currently stored in the map.
@@ -523,8 +601,10 @@ func (s *SwissMapUint64) Clear() {
 // Returns:
 //   - []chainhash.Hash: A slice containing all the hashes in the map.
 func (s *SwissMapUint64) Keys() []chainhash.Hash {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	keys := make([]chainhash.Hash, 0, s.length)
 
@@ -542,8 +622,10 @@ func (s *SwissMapUint64) Keys() []chainhash.Hash {
 // Params:
 //   - f: A function that takes a hash and its associated uint64 value.
 func (s *SwissMapUint64) Iter(f func(hash chainhash.Hash, value uint64) bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	s.m.Iter(func(k chainhash.Hash, v uint64) (stop bool) {
 		return f(k, v)
@@ -560,6 +642,10 @@ func (s *SwissMapUint64) Iter(f func(hash chainhash.Hash, value uint64) bool) {
 // Returns:
 //   - error: An error if the hash does not exist in the map, nil otherwise.
 func (s *SwissMapUint64) Delete(hash chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -578,6 +664,7 @@ func (s *SwissMapUint64) Delete(hash chainhash.Hash) error {
 type SwissLockFreeMapUint64 struct {
 	m      *swiss.Map[uint64, uint64]
 	length atomic.Uint32
+	frozen atomic.Bool
 }
 
 // NewSwissLockFreeMapUint64 creates a new SwissLockFreeMapUint64 with the specified initial length.
@@ -641,6 +728,10 @@ func (s *SwissLockFreeMapUint64) Exists(hash uint64) bool {
 //
 // Considerations: This method does not lock the map, so it is not suitable for concurrent access.
 func (s *SwissLockFreeMapUint64) Put(hash, n uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	exists := s.m.Has(hash)
 	if exists {
 		return ErrHashAlreadyExists

--- a/tx_map.go
+++ b/tx_map.go
@@ -579,12 +579,16 @@ func (s *SwissMapUint64) Length() int {
 }
 
 // Clear empties the map without releasing the underlying group/ctrl backing
-// storage. This is the operation a pool wants: reset state for the next user
-// while keeping the (often multi-GB) preallocation intact.
+// storage, and un-freezes it. This is the operation a pool wants: reset state
+// for the next user while keeping the (often multi-GB) preallocation intact.
 //
-// Safe for concurrent use — takes the write lock. Callers that are about to
-// return a SwissMapUint64 to a sync.Pool should call Clear immediately before
-// Put so the next Get receives a zero-length map.
+// Per the Freeze/Clear contract (see freeze.go), Clear must not run
+// concurrently with any other operation on the map: after Freeze, readers skip
+// the RWMutex, so a concurrent Clear would race their lock-free reads of the
+// underlying map. The write lock only orders Clear against other locked,
+// non-frozen operations. Callers returning a SwissMapUint64 to a sync.Pool
+// should call Clear immediately before Put so the next Get receives a
+// zero-length map.
 func (s *SwissMapUint64) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/tx_map_native.go
+++ b/tx_map_native.go
@@ -23,6 +23,7 @@ type NativeMap struct {
 	mu     sync.RWMutex
 	m      map[chainhash.Hash]struct{}
 	length int
+	frozen atomic.Bool
 }
 
 // NewNativeMap creates a new NativeMap with the specified initial length.
@@ -56,8 +57,10 @@ func NewDefaultMap(length uint32) *NativeMap {
 // Returns:
 //   - bool: True if the hash exists in the map, false otherwise.
 func (s *NativeMap) Exists(hash chainhash.Hash) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	_, ok := s.m[hash]
 
@@ -74,8 +77,10 @@ func (s *NativeMap) Exists(hash chainhash.Hash) bool {
 //   - uint64: Always returns 0, as this map does not store values.
 //   - bool: True if the hash was found in the map, false otherwise.
 func (s *NativeMap) Get(hash chainhash.Hash) (uint64, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	_, ok := s.m[hash]
 
@@ -90,6 +95,10 @@ func (s *NativeMap) Get(hash chainhash.Hash) (uint64, bool) {
 // Returns:
 //   - error: always returns nil, as this map does not have any constraints on adding hashes.
 func (s *NativeMap) Put(hash chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -108,6 +117,10 @@ func (s *NativeMap) Put(hash chainhash.Hash) error {
 // Returns:
 //   - error: always returns nil, as this map does not have any constraints on adding hashes.
 func (s *NativeMap) PutMulti(hashes []chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -128,6 +141,10 @@ func (s *NativeMap) PutMulti(hashes []chainhash.Hash) error {
 // Returns:
 //   - error: always returns nil, as this map does not have any constraints on deleting hashes.
 func (s *NativeMap) Delete(hash chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -143,8 +160,10 @@ func (s *NativeMap) Delete(hash chainhash.Hash) error {
 // Returns:
 //   - int: The number of hashes currently stored in the map.
 func (s *NativeMap) Length() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	return s.length
 }
@@ -156,8 +175,10 @@ func (s *NativeMap) Length() int {
 // Returns:
 //   - []chainhash.Hash: A slice containing all the hashes in the map.
 func (s *NativeMap) Keys() []chainhash.Hash {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	keys := make([]chainhash.Hash, 0, s.length)
 
@@ -179,8 +200,10 @@ func (s *NativeMap) Map() TxHashMap {
 // Params:
 //   - f: A function that takes a hash and its associated value (always 0 in this map).
 func (s *NativeMap) Iter(f func(hash chainhash.Hash, value uint64) bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	for k := range s.m {
 		if f(k, 0) {
@@ -202,6 +225,7 @@ type NativeMapUint64 struct {
 	mu     sync.RWMutex
 	m      map[chainhash.Hash]uint64
 	length int
+	frozen atomic.Bool
 }
 
 // NewNativeMapUint64 creates a new NativeMapUint64 with the specified initial length.
@@ -242,8 +266,10 @@ func (s *NativeMapUint64) Map() map[chainhash.Hash]uint64 {
 // Returns:
 //   - bool: True if the hash exists in the map, false otherwise.
 func (s *NativeMapUint64) Exists(hash chainhash.Hash) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	_, ok := s.m[hash]
 
@@ -261,6 +287,10 @@ func (s *NativeMapUint64) Exists(hash chainhash.Hash) bool {
 // Returns:
 //   - error: An error if the hash already exists in the map, nil otherwise.
 func (s *NativeMapUint64) Put(hash chainhash.Hash, n uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -287,6 +317,10 @@ func (s *NativeMapUint64) Put(hash chainhash.Hash, n uint64) error {
 // Returns:
 //   - error: An error if any of the hashes already exist in the map, nil otherwise.
 func (s *NativeMapUint64) PutMulti(hashes []chainhash.Hash, n uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -314,6 +348,10 @@ func (s *NativeMapUint64) PutMulti(hashes []chainhash.Hash, n uint64) error {
 // Returns:
 //   - error: An error if the hash does not exist in the map, nil otherwise.
 func (s *NativeMapUint64) Set(hash chainhash.Hash, value uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -339,6 +377,10 @@ func (s *NativeMapUint64) Set(hash chainhash.Hash, value uint64) error {
 //   - bool: True if the hash was found and updated, false otherwise.
 //   - error: An error if there was an issue updating the hash, nil otherwise.
 func (s *NativeMapUint64) SetIfExists(hash chainhash.Hash, value uint64) (bool, error) {
+	if s.frozen.Load() {
+		return false, ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -364,6 +406,10 @@ func (s *NativeMapUint64) SetIfExists(hash chainhash.Hash, value uint64) (bool, 
 //   - bool: True if the hash was added, false if it already existed.
 //   - error: An error if there was an issue adding the hash, nil otherwise.
 func (s *NativeMapUint64) SetIfNotExists(hash chainhash.Hash, value uint64) (bool, error) {
+	if s.frozen.Load() {
+		return false, ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -390,8 +436,10 @@ func (s *NativeMapUint64) SetIfNotExists(hash chainhash.Hash, value uint64) (boo
 //   - uint64: The value associated with the hash, or 0 if the hash does not exist.
 //   - bool: True if the hash was found in the map, false otherwise.
 func (s *NativeMapUint64) Get(hash chainhash.Hash) (uint64, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	n, ok := s.m[hash]
 	if !ok {
@@ -407,8 +455,10 @@ func (s *NativeMapUint64) Get(hash chainhash.Hash) (uint64, bool) {
 // Returns:
 //   - int: The number of hashes currently stored in the map.
 func (s *NativeMapUint64) Length() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	return s.length
 }
@@ -420,8 +470,10 @@ func (s *NativeMapUint64) Length() int {
 // Returns:
 //   - []chainhash.Hash: A slice containing all the hashes in the map.
 func (s *NativeMapUint64) Keys() []chainhash.Hash {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	keys := make([]chainhash.Hash, 0, s.length)
 
@@ -438,8 +490,10 @@ func (s *NativeMapUint64) Keys() []chainhash.Hash {
 // Params:
 //   - f: A function that takes a hash and its associated uint64 value.
 func (s *NativeMapUint64) Iter(f func(hash chainhash.Hash, value uint64) bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if !s.frozen.Load() {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+	}
 
 	for k, v := range s.m {
 		if f(k, v) {
@@ -458,6 +512,10 @@ func (s *NativeMapUint64) Iter(f func(hash chainhash.Hash, value uint64) bool) {
 // Returns:
 //   - error: An error if the hash does not exist in the map, nil otherwise.
 func (s *NativeMapUint64) Delete(hash chainhash.Hash) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -481,6 +539,7 @@ type LockFreeMapUint64 = NativeLockFreeMapUint64
 type NativeLockFreeMapUint64 struct {
 	m      map[uint64]uint64
 	length atomic.Uint32
+	frozen atomic.Bool
 }
 
 // NewNativeLockFreeMapUint64 creates a new NativeLockFreeMapUint64 with the specified initial length.
@@ -554,6 +613,10 @@ func (s *NativeLockFreeMapUint64) Exists(hash uint64) bool {
 //
 // Considerations: This method does not lock the map, so it is not suitable for concurrent access.
 func (s *NativeLockFreeMapUint64) Put(hash, n uint64) error {
+	if s.frozen.Load() {
+		return ErrMapFrozen
+	}
+
 	_, exists := s.m[hash]
 	if exists {
 		return ErrHashAlreadyExists


### PR DESCRIPTION
## Problem

Block validation in Teranode (`model.Block.Valid`) has a clean two-phase shape over a `txmap.SplitSwissMapUint64`: phase 1 (`checkDuplicateTransactions`) fills the map with one `Put` per tx; phase 2 (`validOrderAndBlessed`) only reads it, doing one `Get` per tx plus one per parent, fanned out across `runtime.NumCPU()` goroutines. Every `Get` bottoms out in a per-bucket `SwissMapUint64` that takes `mu.RLock()`, and `RLock` performs an atomic add/sub on the reader counter. On a many-core box, with hundreds of goroutines reading the same shards, that reader-counter cache line ping-pongs between CPUs and dominates the profile — the same contention PR #1078 (block-assembly `moveForwardBlock`) measured at ~11% of CPU and eliminated with a `Freeze()`.

This adds the same capability to `go-tx-map` so a populated map can be declared read-only for its read phase, then recycled.

## What changed

- **`Freeze()`** marks a map read-only.
  - On the **lock-based** maps (`SwissMap`, `SwissMapUint64`, `NativeMap`, `NativeMapUint64`, and the `Split*` variants) every read method — `Exists`, `Get`, `Length`, `Keys`, `Iter` — then **skips the per-bucket `RWMutex.RLock`**, replacing it with a single relaxed atomic-bool load. This is the contention win.
  - On the **lock-free** maps (`SwissLockFreeMapUint64`, `*LockFreeMapUint64` and split variants) reads already take no lock, so `Freeze()` only installs the write guard, for API uniformity.
  - Once frozen, every write method (`Put`, `PutMulti`, `Set`, `SetIfExists`, `SetIfNotExists`, `Delete`) returns the new **`ErrMapFrozen`** sentinel rather than silently mutating a map that concurrent readers assume is immutable.
- **`Clear()`** empties a map in place (retaining its preallocated backing storage) and **un-freezes** it, so a pooled map can be recycled: `Clear → Put… → Freeze → Get… → Clear`. Added to the 9 types that lacked it; the 3 existing `Clear()`s now also un-freeze.
- `Freeze()` and `Clear()` are added to the **`TxMap`, `TxHashMap` and `Uint64` interfaces** and implemented on **all 12 concrete map types**. Split maps fan both calls out to every bucket.

The frozen flag is an `atomic.Bool` — a relaxed load on the read path, no cache-line contention.

## Contract

A frozen map must be published to its readers with a happens-before edge (e.g. an `errgroup.Wait()` between the write phase and the read phase). `Freeze()`/`Clear()` are not safe to call concurrently with other operations on the same map — same contract as the existing `Clear()`.

## Tests

New `freeze_test.go`, table-driven across every implementation grouped by interface:

- frozen reads return correct values; every write returns `ErrMapFrozen` and does not mutate; `Clear()` empties and re-enables writes.
- `TestFrozenConcurrentReads` populates, freezes, then reads concurrently from 8 goroutines — validates the lock-free read path is race-free under `-race`.

## Verification

- `go test -race ./...` — pass
- `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `staticcheck ./...` — clean

## Downstream note

Adding `Freeze()`/`Clear()` to the exported `TxMap`/`TxHashMap`/`Uint64` interfaces is an API addition: any external type implementing one of these interfaces (e.g. Teranode's `DiskTxMapUint64`) must add the two methods before bumping this dependency. A follow-up Teranode PR will wire `b.txMap.Freeze()` into `Block.Valid` after the phase-1 flush and have `DiskTxMapUint64` implement the pair.